### PR TITLE
fix: enhance macOS clipboard interoperability, fix path parsing, and prevent spawn crashes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -241,14 +241,24 @@ function M:copy_entry(job)
 
 	-- Try wl-copy first (Wayland) with text/uri-list target
 	ya.dbg("Attempting wl-copy with text/uri-list target...")
-	status, err = Command("wl-copy"):arg("--type"):arg("text/uri-list"):arg(file_list_formatted):spawn():wait()
+	local wl_child, wl_err = Command("wl-copy"):arg("--type"):arg("text/uri-list"):arg(file_list_formatted):spawn()
+	if wl_child then
+		status, err = wl_child:wait()
+	else
+		status, err = nil, wl_err
+	end
 	ya.dbg("wl-copy text/uri-list result: status=%s, err=%s", status and tostring(status.success) or "nil", err or "nil")
 
 	-- If wl-copy fails, try pbcopy (macOS)
 	if not status or not status.success then
 		ya.dbg("wl-copy failed, trying pbcopy...")
 		-- For macOS, use the same text/uri-list format
-		status, err = Command("pbcopy"):arg(file_list_formatted):spawn():wait()
+		local pb_child, pb_err = Command("pbcopy"):arg(file_list_formatted):spawn()
+		if pb_child then
+			status, err = pb_child:wait()
+		else
+			status, err = nil, pb_err
+		end
 		ya.dbg("pbcopy result: status=%s, err=%s", status and tostring(status.success) or "nil", err or "nil")
 	end
 
@@ -256,8 +266,12 @@ function M:copy_entry(job)
 	if not status or not status.success then
 		ya.dbg("pbcopy failed, trying xclip...")
 		-- xclip supports text/uri-list format
-		status, err = Command("xclip"):arg("-selection"):arg("clipboard"):arg("-t"):arg("text/uri-list"):arg(
-			file_list_formatted):spawn():wait()
+		local xclip_child, xclip_err = Command("xclip"):arg("-selection"):arg("clipboard"):arg("-t"):arg("text/uri-list"):arg(file_list_formatted):spawn()
+		if xclip_child then
+			status, err = xclip_child:wait()
+		else
+			status, err = nil, xclip_err
+		end
 		ya.dbg("xclip result: status=%s, err=%s", status and tostring(status.success) or "nil", err or "nil")
 	end
 

--- a/main.lua
+++ b/main.lua
@@ -251,15 +251,42 @@ function M:copy_entry(job)
 
 	-- If wl-copy fails, try pbcopy (macOS)
 	if not status or not status.success then
-		ya.dbg("wl-copy failed, trying pbcopy...")
-		-- For macOS, use the same text/uri-list format
-		local pb_child, pb_err = Command("pbcopy"):arg(file_list_formatted):spawn()
-		if pb_child then
-			status, err = pb_child:wait()
-		else
-			status, err = nil, pb_err
+		ya.dbg("wl-copy failed, trying osascript (JXA) for macOS...")
+		local jxa_script = [[
+function run(argv) {
+    ObjC.import("AppKit");
+    var pb = $.NSPasteboard.generalPasteboard;
+    pb.clearContents;
+    pb.declareTypesOwner($(["NSFilenamesPboardType", "public.utf8-plain-text"]), null);
+    var arr = [];
+    for(var i=0; i<argv.length; i++) arr.push(argv[i]);
+    pb.setPropertyListForType($(arr), "NSFilenamesPboardType");
+    pb.setStringForType(argv.join("\n"), "public.utf8-plain-text");
+}
+]]
+		local jxa_cmd = Command("osascript"):arg("-l"):arg("JavaScript"):arg("-e"):arg(jxa_script)
+		for _, path in ipairs(urls) do
+			jxa_cmd = jxa_cmd:arg(path)
 		end
-		ya.dbg("pbcopy result: status=%s, err=%s", status and tostring(status.success) or "nil", err or "nil")
+		local jxa_child, jxa_err = jxa_cmd:spawn()
+		if jxa_child then
+			status, err = jxa_child:wait()
+		else
+			status, err = nil, jxa_err
+		end
+		ya.dbg("osascript JXA result: status=%s, err=%s", status and tostring(status.success) or "nil", err or "nil")
+
+		-- If osascript JXA fails, try pbcopy
+		if not status or not status.success then
+			ya.dbg("osascript JXA failed, trying pbcopy...")
+			local pb_child, pb_err = Command("pbcopy"):arg(file_list_formatted):spawn()
+			if pb_child then
+				status, err = pb_child:wait()
+			else
+				status, err = nil, pb_err
+			end
+			ya.dbg("pbcopy result: status=%s, err=%s", status and tostring(status.success) or "nil", err or "nil")
+		end
 	end
 
 	-- If both fail, try xclip (X11) with text/uri-list
@@ -549,8 +576,51 @@ end
 
 -- Detect if clipboard contains file URIs and extract all paths
 local function get_clipboard_file_uris()
-	-- Try macOS pbpaste first
-	local handle = io.popen("pbpaste 2>/dev/null")
+	-- Try native macOS file URLs first
+	local mac_script = [[
+osascript -l JavaScript -e '
+function run() {
+    ObjC.import("AppKit");
+    var pb = $.NSPasteboard.generalPasteboard;
+    var files = pb.propertyListForType("NSFilenamesPboardType");
+    if (files) {
+        var arr = ObjC.deepUnwrap(files);
+        if (arr && arr.length > 0) return arr.join("\n");
+    }
+    var items = pb.pasteboardItems;
+    if (!items) return "";
+    var res = [];
+    for(var i=0; i<items.count; i++) {
+        var str = items.objectAtIndex(i).stringForType("public.file-url");
+        if (str) {
+            var fileUrl = $.NSURL.URLWithString(str);
+            if (fileUrl && fileUrl.isFileURL) res.push(fileUrl.path.js);
+        }
+    }
+    return res.join("\n");
+}
+' 2>/dev/null
+]]
+	local handle = io.popen(mac_script)
+	if handle then
+		local content = handle:read("*a")
+		handle:close()
+
+		if content and content:match("^/") then
+			local file_paths = {}
+			for file_path in content:gmatch("[^\r\n]+") do
+				if file_path:match("^/") then
+					table.insert(file_paths, file_path)
+				end
+			end
+			if #file_paths > 0 then
+				return file_paths
+			end
+		end
+	end
+
+	-- Try macOS pbpaste fallback
+	handle = io.popen("pbpaste 2>/dev/null")
 	if handle then
 		local content = handle:read("*a")
 		handle:close()
@@ -1251,9 +1321,20 @@ local function get_clipboard_mimetypes()
 		handle:close()
 
 		if info then
+			local mimetypes = {}
+
+			-- Check if clipboard contains file URLs natively on macOS (e.g. from Finder)
+			local check_files = io.popen("osascript -l JavaScript -e 'function run() { ObjC.import(\"AppKit\"); var pb = $.NSPasteboard.generalPasteboard; var types = pb.types; if (!types) return \"\"; for(var i=0; i<types.count; i++) { var t = types.objectAtIndex(i).js; if (t === \"public.file-url\" || t === \"NSFilenamesPboardType\") return \"text/uri-list\"; } return \"\"; }' 2>/dev/null")
+			if check_files then
+				local is_file = check_files:read("*a")
+				check_files:close()
+				if is_file and is_file:match("text/uri%-list") then
+					table.insert(mimetypes, "text/uri-list")
+				end
+			end
+
 			-- macOS returns different format
 			-- Format: "«class PNGf», «class JPEG», picture, text" etc.
-			local mimetypes = {}
 			for item in info:gmatch("[^,]+") do
 				item = item:match("^%s*(.-)%s*$") -- trim
 				if item and item ~= "" then

--- a/main.lua
+++ b/main.lua
@@ -560,9 +560,9 @@ local function handle_text_uri_list_paste(content)
 		ya.dbg("text/uri-list content:", uri_content or "empty")
 
 		local file_paths = {}
-		for file_path in uri_content:gmatch("file://([^\r\n]+)") do
+		for raw_path in uri_content:gmatch("file://([^\r\n]+)") do
 			-- URL decode the path
-			file_path = file_path:gsub("%%(%x%x)", function(hex)
+			local file_path = raw_path:gsub("%%(%x%x)", function(hex)
 				return string.char(tonumber(hex, 16))
 			end)
 			table.insert(file_paths, file_path)
@@ -1335,8 +1335,8 @@ local function get_clipboard_mimetypes()
 
 			-- macOS returns different format
 			-- Format: "«class PNGf», «class JPEG», picture, text" etc.
-			for item in info:gmatch("[^,]+") do
-				item = item:match("^%s*(.-)%s*$") -- trim
+			for raw_item in info:gmatch("[^,]+") do
+				local item = raw_item:match("^%s*(.-)%s*$") -- trim
 				if item and item ~= "" then
 					table.insert(mimetypes, item)
 				end
@@ -1359,8 +1359,8 @@ local function get_clipboard_mimetypes()
 	if targets then
 		-- Split targets by newline and return as array
 		local mimetypes = {}
-		for mimetype in targets:gmatch("[^\r\n]+") do
-			mimetype = mimetype:match("^%s*(.-)%s*$") -- trim
+		for raw_mime in targets:gmatch("[^\r\n]+") do
+			local mimetype = raw_mime:match("^%s*(.-)%s*$") -- trim
 			if mimetype and mimetype ~= "" then
 				table.insert(mimetypes, mimetype)
 			end

--- a/main.lua
+++ b/main.lua
@@ -614,10 +614,12 @@ local function copy_directory(source_dir, target_dir, no_hover)
 		return false
 	end
 
+	local source_dir_clean = tostring(source_dir):gsub("/+$", "")
+	local source_prefix_len = #source_dir_clean + 2 -- +2 to skip the trailing slash
 	local success = true
 	for line in source_files:lines() do
 		-- Get relative path from source directory
-		local rel_path = line:gsub("^" .. source_dir:gsub("%%", "%%%%") .. "/", "")
+		local rel_path = line:sub(source_prefix_len)
 		local target_file_path = Url(pathJoin(tostring(target_dir), rel_path))
 
 		-- Read source file content
@@ -715,10 +717,12 @@ local function handle_directory_collision(dir_path, source_file_uri, source_file
 					-- Both are directories, recursively overwrite contents
 					local source_files = io.popen("find " .. source_file_uri .. " -type f 2>/dev/null")
 					if source_files then
+						local source_dir_clean = tostring(source_file_uri):gsub("/+$", "")
+						local source_prefix_len = #source_dir_clean + 2
 						local success = true
 						for line in source_files:lines() do
 							-- Get relative path from source directory
-							local rel_path = line:gsub("^" .. source_file_uri:gsub("%%", "%%%%") .. "/", "")
+							local rel_path = line:sub(source_prefix_len)
 							local target_file_path = Url(pathJoin(tostring(target_file), rel_path))
 
 							-- Read source file content


### PR DESCRIPTION
## Description

This PR introduce fixes to integrate with the macOS clipboard. It also patches a crash caused by missing dependencies and fixes a directory copying bug.

### 1. macOS Clipboard Interoperability (JXA)
* **Copy:** Replaced `pbcopy` and with JavaScript for Automation (JXA) script. It natively writes the selected files to the macOS `NSPasteboard`.
* **Paste:** Added a JXA script in `get_clipboard_mimetypes` to detect if the macOS clipboard contains file URLs. Updated `get_clipboard_file_uris` to natively extract and decode items.

### 2. Directory Copying Path Parsing Fix
In `copy_directory` and `handle_directory_collision`, the relative path extraction previously relied on Lua's `gsub` with incomplete escaping (`gsub("%%", "%%%%")`). If a source directory name contained other Lua magic characters (like `-`, `+`, `[`, etc.), the copy operation would fail or produce malformed paths.
* **Fix:** Replaced the regex substitution with an exact substring extraction (`line:sub(source_prefix_len)`), ensuring safety regardless of special characters in folder names.

### 3. `spawn` nil-checks
When executing tools like `wl-copy` or `xclip` via `Command(...):spawn():wait()`, if the command was not installed on the user's system, `spawn()` would return `nil`, causing an `attempt to index a nil value` crash when calling `:wait()`. 
* **Fix:** Added proper nil-checks (`if child then ... else ...`) to gracefully fall back and handle errors without crashing the plugin.

### Testing
Tested on macOS and linux wayland.